### PR TITLE
リリース詳細ページを作成

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,0 +1,9 @@
+class ReleasesController < ApplicationController
+  def show
+    @release = Release.find(params[:id])
+    @q = Release.ransack(params[:q])
+
+    music_brainz_service = MusicBrainzService.new
+    @data = music_brainz_service.fetch_release_details(@release.gid)
+  end
+end

--- a/app/services/music_brainz_service.rb
+++ b/app/services/music_brainz_service.rb
@@ -11,7 +11,7 @@ class MusicBrainzService
 
   def fetch_artist_details(gid)
     sleep_until_allowed
-    url = "#{BASE_URL}/artist/#{gid}?fmt=json" # JSON形式でデータをリクエスト
+    url = "#{BASE_URL}/artist/#{gid}?fmt=json"
     response = request_to_musicbrainz_api(url)
     @last_request_time = Time.now
     JSON.parse(response.body) if response.is_a?(Net::HTTPSuccess)
@@ -19,8 +19,7 @@ class MusicBrainzService
 
   def fetch_release_details(gid)
     sleep_until_allowed
-    # リリース詳細のリクエストにもベースURLとJSONフォーマットを指定
-    url = "#{BASE_URL}/release/#{gid}?fmt=json"
+    url = "#{BASE_URL}/release/#{gid}?inc=recordings&fmt=json"
     response = request_to_musicbrainz_api(url)
     @last_request_time = Time.now
     JSON.parse(response.body) if response.is_a?(Net::HTTPSuccess)

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -28,7 +28,7 @@
           <li class="p-4 hover:bg-gray-100 rounded-lg">
             <div class="flex items-center gap-x-8">
               <p class="text-lg text-gray-900 flex-1">
-                <%= link_to release.name, "#" %>
+                <%= link_to release.name, release_path(release) %>
               </p>
               <p class="text-sm text-gray-800 flex-1">
                 <% release.mediums.each_with_index do |medium, index| %>

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -1,0 +1,50 @@
+<div class="container mx-auto pt-6 px-4">
+  <div class="flex flex-wrap justify-center">
+    <div class="w-full lg:w-10/12">
+      <%= render 'shared/search_form', q: @q, url: search_path, class: "mb-6" %>
+
+      <div class="card bg-base-100 shadow-xl">
+        <div class="card-body">
+          <h1 class="card-title text-6xl font-bold"><%= @release.name %></h1>
+          <p class="text-xl text-gray-600 mb-4"><%= @release.artist_credit.name %></p>
+            
+          <% if @data.present? %>
+            <div class="mb-4">
+              <% @release.mediums.each do |medium| %>
+                <% if medium.medium_format.present? %>
+                  <p><strong><%= t('results.columns.format') %>:</strong> <%= medium.medium_format.name %>
+                <% else %>
+                  <%= " " %>
+                <% end %>
+              <% end %>
+              <p><strong><%= t('releases.show.release_date') %>:</strong> <%= @data["date"] %></p>
+              <p><strong><%= t('releases.show.press_country') %>:</strong> <%= @data["country"] %></p>
+              <p><strong><%= t('releases.show.status') %>:</strong> <%= @data["status"] %></p>
+            </div>
+
+            <% if @data["media"].present? %>
+              <% @data["media"].each do |media| %>
+                <div class="mb-4">
+                  <p><strong><%= t('releases.show.track_count') %>:</strong>:</strong> <%= media["track-count"] %></p>
+                </div>
+
+                <div class="pl-4">
+                  <h3 class="text-xl font-bold mb-2"><%= t('releases.show.track_list') %></h3>
+                  <ul class="list-disc">
+                    <% media["tracks"].each do |track| %>
+                      <li class="ml-6"><%= track["title"] %></li>
+                    <% end %> <!-- media["tracks"].eachの終了タグ -->
+                  </ul>
+                </div>
+              <% end %> <!-- @release["media"].eachの終了タグ -->
+            <% else %>
+              <p><%= t('releases.show.track_not_available') %></p>
+            <% end %>
+          <% else %>
+            <p><%= t('releases.show.details_not_available') %></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/search/_releases_results.erb
+++ b/app/views/search/_releases_results.erb
@@ -8,7 +8,7 @@
     <div class="mt-4 p-4 hover:bg-gray-100 rounded-lg">
       <div class="mb-2 flex">
         <p class="flex-1 text-lg text-gray-900">
-          <%= link_to release.name, "#", class: "text-gray-800 text-lg" %>
+          <%= link_to release.name, release_path(release), class: "text-gray-800 text-lg" %>
         </p>
         <p class="flex-1 text-gray-800">
           <%= release.artist_credit.name %>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -54,3 +54,13 @@ ja:
       disambiguation: 認識情報
       country: 国籍
       details_not_available: アーティストの詳細情報はありません。
+  releases:
+    show:
+      release_date: リリース日
+      press_country: プレス国
+      status: ステータス
+      media_info: メディア情報
+      track_not_available: トラック情報はありません。
+      track_count: トラック数
+      track_list: トラックリスト
+      details_not_available: リリースの詳細情報はありません。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
+  get 'releases/show'
   root 'static_pages#top'
   resources :users, only: %i[new create]
   resources :artists, only: %i[show]
+  resources :releases, only: %i[show]
 
   get 'search', to: 'search#index'
   get 'login', to: 'user_sessions#new'


### PR DESCRIPTION
# 概要
リリース詳細ページを作成

## 内容
- リリース作品の詳細を表示するコントローラー・ビューを作成
- MusicBrainzAPIにリクエストを送信するMusicBrainzServiceクラスを修正
- MusicBrainzAPIから受け取ったデータをビューに表示