### PR TITLE
release_formatsテーブル再作成/コントローラー修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,7 +31,7 @@ class ItemsController < ApplicationController
   end
 
   def create
-    @item = current_user.items.build(item_params.except(:title, :artist_name, :release_format, :press_country, :matrix_number, accessory_ids: []))
+    @item = current_user.items.build(item_params.except(:title, :artist_name, :release_format, :press_country, :matrix_number, :tag, accessory_ids: []))
 
     @item.find_or_create_related_objects({
                                            title: params[:item][:title],
@@ -85,7 +85,7 @@ class ItemsController < ApplicationController
     tag_names = params[:item][:tag]&.split(',') || []
     @item.save_with_tags(tag_names:)
 
-    if @item.update(item_params.except(:title, :artist_name, :release_format, :press_country, :matrix_number, accessory_ids: []))
+    if @item.update(item_params.except(:title, :artist_name, :release_format, :press_country, :matrix_number, :tag, accessory_ids: []))
       if @item.role == 'collection'
         redirect_to collection_items_path, notice: t('items.edit.edit')
       else
@@ -120,7 +120,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:title, :artist_name, :release_format, :press_country, :matrix_number, :condition_id, :user_note, :role, accessory_ids: [])
+    params.require(:item).permit(:title, :artist_name, :release_format, :press_country, :matrix_number, :condition_id, :user_note, :role, :tag, accessory_ids: [])
   end
 
   def set_item

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,8 +3,8 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV.fetch('DB_USERNAME') %>
-  password: <%= ENV.fetch('DB_PASSWORD') %>
+  username: <%= ENV.fetch('POSTGRES_USER') %>
+  password: <%= ENV.fetch('POSTGRES_PASSWORD') %>
   host: <%= ENV.fetch('DB_HOST') %>
   port: <%= ENV.fetch('DB_PORT') %>
 

--- a/db/migrate/20240326094536_release_formats.rb
+++ b/db/migrate/20240326094536_release_formats.rb
@@ -1,0 +1,7 @@
+class ReleaseFormats < ActiveRecord::Migration[7.1]
+  def change
+    create_table :release_formats do |t|
+      t.string :name, null: false
+    end
+  end
+end

--- a/db/migrate/20240326095153_add_release_format_id_to_items.rb
+++ b/db/migrate/20240326095153_add_release_format_id_to_items.rb
@@ -1,0 +1,5 @@
+class AddReleaseFormatIdToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :items, :release_format, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_17_080642) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_26_095153) do
   create_schema "_heroku"
 
   # These are extensions that must be enabled in order to support this database
@@ -76,10 +76,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_17_080642) do
     t.integer "role", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "release_format_id"
     t.index ["artist_name_id"], name: "index_items_on_artist_name_id"
     t.index ["condition_id"], name: "index_items_on_condition_id"
     t.index ["matrix_number_id"], name: "index_items_on_matrix_number_id"
     t.index ["press_country_id"], name: "index_items_on_press_country_id"
+    t.index ["release_format_id"], name: "index_items_on_release_format_id"
     t.index ["title_id"], name: "index_items_on_title_id"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
@@ -103,6 +105,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_17_080642) do
   create_table "press_countries", force: :cascade do |t|
     t.string "name", null: false
     t.index ["name"], name: "index_press_countries_on_name", unique: true
+  end
+
+  create_table "release_formats", force: :cascade do |t|
+    t.string "name", null: false
   end
 
   create_table "releases", force: :cascade do |t|
@@ -145,6 +151,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_17_080642) do
   add_foreign_key "items", "conditions"
   add_foreign_key "items", "matrix_numbers"
   add_foreign_key "items", "press_countries"
+  add_foreign_key "items", "release_formats"
   add_foreign_key "items", "titles"
   add_foreign_key "items", "users"
   add_foreign_key "mediums", "medium_formats"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   db:
     image: postgres
     environment:
-      DB_USER: postgres
-      DB_PASSWORD: password
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
     volumes:
       - postgres_volume:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
# 概要
release_formatsテーブル再作成/コントローラー修正

## 内容
- release_formatsテーブルのマイグレーションファイルを削除してしまったため再作成
- itemsコントローラーのparamsにtagが含まれていなかったため追加
- ローカル環境のデータベース接続設定を修正