### PR TITLE
artist・release検索フォームをヘッダーに移動

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,32 @@
 class ApplicationController < ActionController::Base
   before_action :require_login
+  before_action :set_search
   add_flash_types :success, :danger
+
+  helper_method :current_user
+
+  def set_search
+    @q = get_global_search_query(params[:q], params[:type])
+  end
 
   private
 
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+
   def not_authenticated
     redirect_to login_path, danger: t('defaults.flash_message.require_login')
+  end
+
+  def get_global_search_query(search_params, type)
+    case type
+    when 'artist'
+      Artist.ransack(search_params)
+    when 'release'
+      Release.ransack(search_params)
+    else
+      Artist.none.ransack
+    end
   end
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,4 +1,6 @@
 class ArtistsController < ApplicationController
+  skip_before_action :require_login, only: [:show]
+
   def show
     @artist = Artist.find(params[:id])
     @q = Artist.ransack(params[:q])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,13 +7,13 @@ class ItemsController < ApplicationController
     case params[:view_type]
     when 'collection_items'
       items = current_user.items.collection_items
-      @q = items.ransack(params[:q])
-      @items = @q.result.page(params[:page]).per(20)
+      @items_search = items.ransack(params[:q])  # ここを変更
+      @items = @items_search.result.page(params[:page]).per(20)
       render 'collection_items'
     when 'want_items'
       items = current_user.items.want_items
-      @q = items.ransack(params[:q])
-      @items = @q.result.page(params[:page]).per(20)
+      @items_search = items.ransack(params[:q])  # ここを変更
+      @items = @items_search.result.page(params[:page]).per(20)
       render 'want_items'
     end
   end

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,4 +1,6 @@
 class ReleasesController < ApplicationController
+  skip_before_action :require_login, only: [:show]
+
   def show
     @release = Release.find(params[:id])
     @q = Release.ransack(params[:q])

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,4 +1,6 @@
 class SearchController < ApplicationController
+  skip_before_action :require_login, only: [:index]
+
   def index
     @type = params[:type]
     @q = get_search_query(@type, params[:q])

--- a/app/services/music_brainz_service.rb
+++ b/app/services/music_brainz_service.rb
@@ -3,7 +3,7 @@ class MusicBrainzService
   require 'uri'
 
   # MusicBrainz APIのベースURL
-  BASE_URL = 'https://musicbrainz.org/ws/2'
+  BASE_URL = 'https://musicbrainz.org/ws/2'.freeze
 
   def initialize
     @last_request_time = nil

--- a/app/views/items/collection_items.html.erb
+++ b/app/views/items/collection_items.html.erb
@@ -1,8 +1,8 @@
 <div class="container mx-auto mt-8">
   <h1 class="text-2xl font-bold text-center mb-8"><%= t('my_interests.collection_list') %></h1>
 
-  <%= search_form_for @q, url: collection_items_path, method: :get, class: "space-y-4" do |f| %>
-    <div class="flex items-center">
+  <%= search_form_for @items_search , url: collection_items_path, method: :get, class: "space-y-4" do |f| %>
+    <div class="flex justify-center items-center mx-4">
       <%= f.search_field :title_name_or_artist_name_name_cont, placeholder: t('search.in_collection_list'), class: "input input-bordered w-full max-w-xs" %>
       <button type="submit" class="btn btn-primary ml-2">
         <img alt="Search" src="https://static.metabrainz.org/MB/search-52f8034.svg" class="w-4 h-4">

--- a/app/views/items/want_items.html.erb
+++ b/app/views/items/want_items.html.erb
@@ -1,8 +1,8 @@
 <div class="container mx-auto mt-8">
   <h1 class="text-2xl font-bold text-center mb-8"><%= t('my_interests.wantlist') %></h1>
 
-  <%= search_form_for @q, url: want_items_path, method: :get, class: "space-y-4" do |f| %>
-    <div class="flex items-center">
+  <%= search_form_for @items_search , url: want_items_path, method: :get, class: "space-y-4" do |f| %>
+    <div class="flex justify-center items-center mx-4">
       <%= f.search_field :title_name_or_artist_name_name_cont, placeholder: t('search.in_want_list'), class: "input input-bordered w-full max-w-xs" %>
       <button type="submit" class="btn btn-primary ml-2">
         <img alt="Search" src="https://static.metabrainz.org/MB/search-52f8034.svg" class="w-4 h-4">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,14 +1,11 @@
 <div class="container mx-auto pt-3">
   <div class="flex flex-wrap">
     <div class="w-full lg:w-10/12 lg:mx-auto">
-      <%= render 'shared/search_form', q: @q, url: search_path %>
 
       <div class="mt-4">
         <% if @results.blank? %>
           <% if params[:q].present? %>
             <p><%= t('search.no_results') %></p>
-          <% else %>
-            <%= render 'search_instructions' %>
           <% end %>
         <% else %>
           <% case @type %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -3,7 +3,10 @@
     <div class="flex-1">
       <a class="btn btn-ghost text-xl">VinylLog</a>
     </div>
-    <div class="flex-none gap-2">
+    <div class="flex justify-center items-center mx-4">
+      <%= render 'shared/search_form', q: @q, url: search_path %>
+    </div>
+    <div class="flex-1 justify-end flex">
       <%= link_to t('header.to_register_page'), new_user_path, class: "btn btn-ghost" %>
       <%= link_to t('header.login'), login_path, class: "btn btn-ghost" %>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,10 @@
     <div class="flex-1">
       <a class="btn btn-ghost text-xl">VinylLog</a>
     </div>
-    <div class="flex-none">
+    <div class="flex justify-center items-center mx-4">
+      <%= render 'shared/search_form', q: @q, url: search_path %>
+    </div>
+    <div class="flex-1 justify-end flex">
       <button class="btn btn-square btn-ghost" id="menuToggle">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
@@ -20,7 +23,6 @@
     <ul>
       <%= link_to t('header.home'), "#", class: "block p-2" %>
       <%= link_to t('header.search_shops'), "#", class: "block p-2" %>
-      <%= link_to t('header.add_item'), search_path, class: "block p-2" %>
       <li>
         <%= link_to t('header.my_page'), "#", class: "block p-2" %>
         <ul class="pl-4">


### PR DESCRIPTION
# 概要
artist・release検索フォームをヘッダーに移動

## 内容
- 検索フォームをヘッダーに移動
- itemsコントローラーの検索用変数名を変更
- music_brainz_service.rbのLintエラーを修正