### PR TITLE
GooglePlacesAPIからショップ情報を取得 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,9 @@ gem 'simple_calendar'
 gem 'chartkick'
 gem 'groupdate'
 
+# ショップ情報取得
+gem 'google_places'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.1)
       irb (~> 1.10)
@@ -173,9 +174,15 @@ GEM
       i18n (>= 0.7)
       multi_json
       request_store (>= 1.0)
+    google_places (2.0.0)
+      httparty (>= 0.13.1)
     groupdate (6.4.0)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -434,6 +441,7 @@ DEPENDENCIES
   factory_bot_rails
   fog-aws
   gon
+  google_places
   groupdate
   jbuilder
   jsbundling-rails

--- a/lib/tasks/import_shops.rake
+++ b/lib/tasks/import_shops.rake
@@ -1,0 +1,75 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+namespace :shop do
+  desc "Import record shops from Google Places API"
+  task import: :environment do
+    api_base_url = "https://maps.googleapis.com/maps/api/place"
+    api_key = ENV['API_KEY']
+
+    search_uri = URI("#{api_base_url}/textsearch/json")
+    search_params = {
+      query: 'record shops in Ikebukuro',
+      language: 'ja',
+      type: 'store',
+      key: api_key
+    }
+    search_uri.query = URI.encode_www_form(search_params)
+
+    search_response = Net::HTTP.get_response(search_uri)
+    if search_response.is_a?(Net::HTTPSuccess)
+      search_results = JSON.parse(search_response.body)['results']
+
+      search_results.each do |result|
+        place_id = result['place_id']
+        details_uri = URI("#{api_base_url}/details/json")
+        details_params = {
+          place_id: place_id,
+          key: api_key,
+          language: 'ja',
+          fields: 'formatted_address,name,formatted_phone_number,opening_hours,website,geometry,photo'
+        }
+        details_uri.query = URI.encode_www_form(details_params)
+
+        begin
+          details_response = Net::HTTP.get_response(details_uri)
+          details = JSON.parse(details_response.body)['result']
+
+          Shop.find_or_create_by(place_id: place_id) do |shop|
+            shop.name = details['name']
+            shop.address = details['formatted_address'].sub(/^日本、\s*〒\d{3}-\d{4}\s*/, '')
+            shop.phone_number = details['formatted_phone_number']
+            shop.opening_hours = details['opening_hours']['weekday_text'].join(", ") if details['opening_hours']
+            shop.web_site = details['website']
+            shop.shop_image = fetch_photo_url(details.dig('photos', 0, 'photo_reference'), api_key, api_base_url) if details['photos']&.any?
+            shop.latitude = details.dig('geometry', 'location', 'lat')
+            shop.longitude = details.dig('geometry', 'location', 'lng')
+            shop.postal_code = extract_postal_code(details['formatted_address'])
+          end
+          puts "#{details['name']}の保存が完了しました。"
+        rescue => e
+          puts "#{details['name']}の保存に失敗しました。#{e.message}"
+        end
+      end
+    else
+      puts "APIリクエストに失敗しました。#{search_response.body}"
+    end
+  end
+
+  def self.extract_postal_code(address)
+    match = address.match(/〒(\d{3}-\d{4})/)
+    match ? match[1] : nil
+  end
+
+  def self.fetch_photo_url(photo_reference, api_key, api_base_url)
+    uri = URI("#{api_base_url}/photo")
+    params = {
+      maxwidth: 400,
+      photoreference: photo_reference,
+      key: api_key
+    }
+    uri.query = URI.encode_www_form(params)
+    uri.to_s
+  end
+end


### PR DESCRIPTION
# 概要
GooglePlacesAPIを使用してレコードショップ情報を取得

## 内容
- Gem google_places追加
- GooglePlacesAPIへリクエストを送信、取得したショップ情報をDBに保存するRakeタスクを作成