### PR TITLE
UI微修正

### DIFF
--- a/app/javascript/controllers/avatar_preview_controller.js
+++ b/app/javascript/controllers/avatar_preview_controller.js
@@ -3,6 +3,13 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["preview", "input"]
 
+  connect() {
+    this.previewTarget.style.width = "120px"
+    this.previewTarget.style.height = "120px"
+    this.previewTarget.style.objectFit = "cover"
+    this.previewTarget.style.objectPosition = "center"
+  }
+
   preview(event) {
     const file = this.inputTarget.files[0]
     const reader = new FileReader()

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -26,7 +26,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # end
 
   # Process files as they are uploaded:
-  process resize_to_fit: [120, 120]
+  process resize_to_fill: [120, 120]
   #
   # def scale(width, height)
   #   # do something

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -15,16 +15,16 @@
 
     <!-- md以下の画面サイズで表示 -->
     <div class="md:hidden flex items-center">
-      <div class="dropdown dropdown-bottom dropdown-end">
-        <div tabindex="0" role="button" class="btn btn-ghost">
+      <details class="dropdown dropdown-bottom dropdown-end">
+        <summary tabindex="0" role="button" class="btn btn-ghost">
           <span class="i-bi-search bg-accent w-4 h-4" aria-hidden="true"></span>
-        </div>
+        </summary>
         <div tabindex="0" class="dropdown-content menu z-[1] fixed w-full">
           <div class="container mx-auto">
             <%= render 'shared/search_form', q: @q, url: search_path %>
           </div>
         </div>
-      </div>
+      </details>
 
       <%= link_to login_path, class: "btn btn-ghost" do %>
         <span class="i-material-symbols-login bg-accent w-5 h-5" aria-hidden="true"></span>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,16 +19,16 @@
           <div class="btn btn-ghost">
            <%= render 'shared/add_btn' %>
           </div>
-          <div class="dropdown dropdown-bottom dropdown-end">
-            <div tabindex="0" role="button" class="btn btn-ghost ml-auto">
+          <details class="dropdown dropdown-bottom dropdown-end">
+            <summary tabindex="0" role="button" class="btn btn-ghost ml-auto">
               <span class="i-bi-search bg-accent w-4 h-4" aria-hidden="true"></span>
-            </div>
+            </summary>
             <div tabindex="0" class="dropdown-content menu z-[1] fixed w-full">
               <div class="container mx-auto">
                 <%= render 'shared/search_form', q: @q, url: search_path %>
               </div>
             </div>
-          </div>
+          </details>
         </div>
 
         <div>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -21,7 +21,7 @@
       <span class="i-bi-house-door-fill bg-primary w-4 h-4 mr-1" aria-hidden="true"></span>
       <%= t('shops.web_site') %>
     </div>
-    <div class="text-accent link link-hover mb-6"><%= link_to @shop.web_site, @shop.web_site, target: "_blank", rel: "noopener" %></div>
+    <div class="text-accent link link-hover mb-6 break-all"><%= link_to @shop.web_site, @shop.web_site, target: "_blank", rel: "noopener" %></div>
 
     <div class="text-white font-bold mb-2">
       <span class="i-bi-telephone-fill bg-primary w-4 h-4 mr-1" aria-hidden="true"></span>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -59,7 +59,7 @@ ja:
     privacy_policy: プライバシーポリシー
   search:
     button: 検索
-    no_results: 検索結果が見つかりませんでした。
+    no_results: 検索結果が見つかりませんでした
     in_collection_list: コレクション内検索
     in_want_list: 欲しいもの内検索
     form:
@@ -79,7 +79,7 @@ ja:
       life_span: 活動期間
       disambiguation: 認識情報
       country: 国籍
-      details_not_available: アーティストの詳細情報はありません。
+      details_not_available: アーティストの詳細情報はありません
       no_vinyl_release: レコードのリリース情報が見つかりませんでした
   releases:
     show:
@@ -87,10 +87,10 @@ ja:
       press_country: プレス国
       status: ステータス
       media_info: メディア情報
-      track_not_available: トラック情報はありません。
+      track_not_available: トラック情報はありません
       track_count: トラック数
       track_list: トラックリスト
-      details_not_available: リリースの詳細情報はありません。
+      details_not_available: リリースの詳細情報はありません
   items:
     confirm_delete: 本当に削除しますか？
     role_updated_to_collection: 欲しいものをコレクションに移動しました
@@ -111,8 +111,8 @@ ja:
       edit_want: 欲しいのもの編集
     index:
       tag: タグ
-      not_found: 指定されたアイテムが見つかりません。
-      no_items: アイテムがありません。
+      not_found: 指定されたアイテムが見つかりません
+      no_items: アイテムがありません
     show:
       collection_show: コレクション詳細
       want_show: 欲しいもの詳細
@@ -123,8 +123,8 @@ ja:
       no_user_note: メモがありません
     delete:
       success:
-        collection: コレクションを削除しました。
-        want: 欲しいものを削除しました。
+        collection: コレクションを削除しました
+        want: 欲しいものを削除しました
   records:
     confirm_delete: 本当に削除しますか？
     new:
@@ -146,7 +146,7 @@ ja:
       title: 記録詳細
       no_content: コメントがありません
     delete:
-      success: 記録を削除しました。
+      success: 記録を削除しました
     update:
       saved: 記録を編集しました
     report_show:
@@ -156,8 +156,8 @@ ja:
       top_records: よく聴いたレコード
   my_page:
     title: マイページ
-    what_to_listen: 何を聞きますか？
-    add_to_collection: コレクションをリストに追加しましょう。
+    what_to_listen: 何を聴きますか？
+    add_to_collection: コレクションをリストに追加しましょう
     details: 詳細
   profile:
     show:


### PR DESCRIPTION
# 概要
UI微修正

## 内容
- ショップ詳細の公式ページURLが親要素の横幅を超えた場合、折り返すよう修正
- モバイル端末の場合、検索アイコンをタップして検索フォームを開閉するよう変更
- 全体の文言を微修正
- ユーザーアバターが正方形で保存されるよう変更