### PR TITLE
リリース詳細ページのバグ修正

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -2,7 +2,7 @@ class ReleasesController < ApplicationController
   skip_before_action :require_login, only: [:show]
 
   def show
-    @release = Release.find(params[:id])
+    @release = Release.includes(mediums: :medium_format).find(params[:id])
     @q = Release.ransack(params[:q])
 
     music_brainz_service = MusicBrainzService.new

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -7,12 +7,14 @@
     <% if @data.present? %>
       <div class="mb-4 flex justify-between">
         <div>
-          <% @release.mediums.each do |medium| %>
-            <% if medium.medium_format.present? %>
-              <div class="text-sm md:text-base"><%= t('results.columns.format') %> : <%= medium.medium_format.name %></div>
-            <% else %>
-              <%= " " %>
+          <% if @release.mediums.any? %>
+            <% @release.mediums.each do |medium| %>
+              <% if medium.medium_format.present? %>
+                <div class="text-sm md:text-base"><%= t('results.columns.format') %> : <%= medium.medium_format.name %></div>
+              <% end %>
             <% end %>
+          <% else %>
+            <div class="text-sm md:text-base"><%= t('results.columns.format') %> : <%= " " %></div>
           <% end %>
           <div class="text-sm md:text-base"><%= t('releases.show.release_date') %> : <%= @data["date"] %></div>
           <div class="text-sm md:text-base"><%= t('releases.show.press_country') %> : <%= @data["country"] %></div>
@@ -22,7 +24,7 @@
           <%= link_to new_item_path(role: 'collection', 
                                     title: @release.name, 
                                     artist_name: @release.artist_credit.name, 
-                                    release_format: @release.mediums.find { |m| m.medium_format.present? }.medium_format.name, 
+                                    release_format: @release.mediums.find { |m| m.medium_format.present? }&.medium_format&.name, 
                                     press_country: @data["country"]), 
                       class: "btn btn-primary btn-block text-white" do %>
             <%= t('items.new.add_to_collection') %>
@@ -31,7 +33,7 @@
           <%= link_to new_item_path(role: 'want', 
                                     title: @release.name, 
                                     artist_name: @release.artist_credit.name, 
-                                    release_format: @release.mediums.find { |m| m.medium_format.present? }.medium_format.name, 
+                                    release_format: @release.mediums.find { |m| m.medium_format.present? }&.medium_format&.name, 
                                     press_country: @data["country"]), 
                       class: "btn btn-primary btn-block text-white" do %>
             <%= t('items.new.add_to_wishlist') %>


### PR DESCRIPTION
# 概要
releaseに紐づくmediumがない場合のバグ修正

## 内容
本番環境にreleasesテーブルの初期データインポート中。
mediumsテーブル(releasesとmedium_formatsの中間テーブル)のデータをインポートするまで、
リリース詳細ページにバグが発生するため、mediumがない場合、空欄を返すよう修正。
