### PR TITLE
パスワードリセット・メールアドレス変更機能バグ修正

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -24,6 +24,7 @@ class EmailsController < ApplicationController
 
     # ユーザーがメールアドレス確認メールのリンクを開くとemailを更新する
     if token_user.update(email: token_user.new_email, new_email: nil, confirmation_token: nil)
+      logout
       redirect_to login_path, notice: t('emails.edit.edit')
     else
       redirect_to root_path, alert: t('emails.edit.not_edited')

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -15,15 +15,15 @@ class EmailsController < ApplicationController
   end
 
   def confirm_email
-    token_user = User.find_by(email_change_token: params[:token])
+    token_user = User.find_by(confirmation_token: params[:token])
 
-    unless token_user&.email_change_token_valid?
+    unless token_user&.confirmation_token_valid?
       redirect_to root_path, alert: t('emails.edit.invalid_token')
       return
     end
 
     # ユーザーがメールアドレス確認メールのリンクを開くとemailを更新する
-    if token_user.update(email: token_user.new_email, new_email: nil, email_change_token: nil)
+    if token_user.update(email: token_user.new_email, new_email: nil, confirmation_token: nil)
       redirect_to login_path, notice: t('emails.edit.edit')
     else
       redirect_to root_path, alert: t('emails.edit.not_edited')

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -6,7 +6,7 @@ class PasswordResetsController < ApplicationController
   def create
     @user = User.find_by(email: params[:email])
     @user&.deliver_reset_password_instructions!
-    redirect_to login_path, notice: t('.success')
+    redirect_to root_path, notice: t('.success')
   end
 
   def edit
@@ -23,6 +23,7 @@ class PasswordResetsController < ApplicationController
 
     @user.password_confirmation = params[:user][:password_confirmation]
     if @user.change_password(params[:user][:password])
+      logout
       redirect_to login_path, notice: t('.success')
     else
       flash.now[:alert] = t('.fail')

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,7 +10,7 @@ class UserMailer < ApplicationMailer
 
   def email_reconfirmation(user)
     @user = User.find(user.id)
-    @token = user.generate_email_change_token
+    @token = user.generate_confirmation_token
     @url = confirm_email_url(token: @token)
     mail(to: @user.new_email,
          subject: t('defaults.confirm_change_email'))

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true
   validates :reset_password_token, uniqueness: true, allow_nil: true
-  validates :email_change_token, uniqueness: true, allow_nil: true
+  validates :confirmation_token, uniqueness: true, allow_nil: true
 
   has_many :items, dependent: :destroy
   has_many :records, dependent: :destroy
@@ -19,15 +19,15 @@ class User < ApplicationRecord
 
   enum role: { general: 0, admin: 1 }
 
-  def generate_email_change_token
-    self.email_change_token = SecureRandom.urlsafe_base64.to_s
-    self.email_change_token_sent_at = Time.current
+  def generate_confirmation_token
+    self.confirmation_token = SecureRandom.urlsafe_base64.to_s
+    self.confirmation_sent_at = Time.current
     save!
-    email_change_token
+    confirmation_token
   end
 
-  def email_change_token_valid?
-    email_change_token.present? && email_change_token_sent_at > 2.hours.ago
+  def confirmation_token_valid?
+    confirmation_token.present? && confirmation_sent_at > 2.hours.ago
   end
 
   def bookmark(shop)

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -22,7 +22,7 @@
               d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z"
               clip-rule="evenodd" />
           </svg>
-          <%= f.password_field :password, class: "input input-bordered bg-white text-base-100 w-full pl-10", placeholder: 'Password' %>
+          <%= f.password_field :password, class: "input input-bordered bg-white text-base-100 w-full pl-10", placeholder: 'Password', required: true %>
         </div>
       </div>
 
@@ -39,7 +39,7 @@
               d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z"
               clip-rule="evenodd" />
           </svg>
-          <%= f.password_field :password_confirmation, class: "input input-bordered bg-white text-base-100 w-full pl-10", placeholder: 'Confirm Password' %>
+          <%= f.password_field :password_confirmation, class: "input input-bordered bg-white text-base-100 w-full pl-10", placeholder: 'Confirm Password', required: true %>
         </div>
       </div>
 

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -178,6 +178,7 @@ ja:
       success: パスワードリセット手順を送信しました
     update:
       success: パスワードを変更しました
+      fail: パスワードを変更できませんでした
   emails:
     edit:
       title: メールアドレス変更

--- a/db/migrate/20240928051830_rename_email_change_token_to_confirmation.rb
+++ b/db/migrate/20240928051830_rename_email_change_token_to_confirmation.rb
@@ -1,0 +1,6 @@
+class RenameEmailChangeTokenToConfirmation < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :users, :email_change_token, :confirmation_token
+    rename_column :users, :email_change_token_sent_at, :confirmation_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_27_111410) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_28_051830) do
+  create_schema "_heroku"
+
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "accessories", force: :cascade do |t|
@@ -190,10 +193,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_27_111410) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.string "new_email"
-    t.string "email_change_token"
-    t.datetime "email_change_token_sent_at"
+    t.string "confirmation_token"
+    t.datetime "confirmation_sent_at"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, where: "(confirmation_token IS NOT NULL)"
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["email_change_token"], name: "index_users_on_email_change_token", unique: true, where: "(email_change_token IS NOT NULL)"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
# 概要
パスワードリセット・メールアドレス変更機能バグ修正

## 内容
#### メールアドレス変更機能
- メールアドレス変更用のトークンの名前が、email_change_tokenだとSorceryに認識されなかったため、デフォルトのconfirmation_tokenに戻した
- メールアドレス変更後にログアウトされるよう修正

#### パスワードリセット機能
- パスワードリセット失敗時に表示されるフラッシュメッセージを追加
- パスワードリセット手順メールを送信したらトップページにリダイレクトするよう変更
- パスワード変更フォームが空欄だと保存できないよう修正
- パスワードリセット後にログアウトされるよう修正