### PR TITLE
記録一覧機能/レポート詳細機能修正

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -62,7 +62,9 @@ class RecordsController < ApplicationController
 
   def daily_records
     date = Date.parse(params[:date])
-    @records = current_user.records.where('DATE(created_at) = ?', date).page(params[:page]).per(6)
+    @records = current_user.records
+                           .where(created_at: date.in_time_zone.all_day)
+                           .page(params[:page]).per(6)
   end
 
   def destroy

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -24,7 +24,7 @@
           <%= render 'shared/pie_chart' %>
         </div>
         <div class="text-right text-sm text-primary link link-hover">
-          <%= link_to t('my_page.details'), report_show_records_path %>
+          <%= link_to t('my_page.details'), report_show_records_path(month: @date.strftime('%Y-%m')) %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# 概要
記録一覧機能機能/レポート詳細機能修正

## 内容
- report_show_records_pathに@date.strftime('%Y-%m')形式のmonthパラメータを追加し、カレンダーに表示されている月と、詳細ボタンクリック時に遷移するレポート詳細ページの表示月を一致させた
- Recordsコントローラーのdaily_recordsアクションを修正し、created_atの日付比較をアプリケーションのタイムゾーン（東京）に基づいて行うように変更（DATE() 関数はデータベース側の関数で、データベースのタイムゾーン設定に依存するようだった）