### PR TITLE
レポート集計方法を修正

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -49,7 +49,10 @@ class RecordsController < ApplicationController
 
   def update
     if @record.update(record_params)
-      update_record_items
+      @record.record_items.destroy_all
+      params[:item_ids].each do |item_id|
+        @record.record_items.create(item_id:)
+      end
       redirect_to record_path(@record), notice: t('defaults.flash_message.updated', item: Record.model_name.human)
     else
       flash.now[:alert] = t('defaults.flash_message.not_updated', item: Record.model_name.human)
@@ -94,30 +97,5 @@ class RecordsController < ApplicationController
 
   def determine_date
     params[:month] ? Date.strptime(params[:month], '%Y-%m') : Date.current
-  end
-
-  def update_record_items
-    existing_items = @record.record_items.to_a
-    update_existing_items(existing_items)
-    remove_excess_items(existing_items)
-  end
-
-  def update_existing_items(existing_items)
-    params[:item_ids].each_with_index do |item_id, index|
-      if existing_items[index]
-        # 既存のrecord_itemがある場合は更新
-        existing_items[index].update(item_id:)
-      else
-        # 既存のrecord_itemがない場合は作成
-        @record.record_items.create(item_id:)
-      end
-    end
-  end
-
-  # record編集時に不要になったrecord_itemを削除
-  def remove_excess_items(existing_items)
-    return unless existing_items.length > params[:item_ids].length
-
-    existing_items[params[:item_ids].length..].each(&:destroy)
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -49,10 +49,7 @@ class RecordsController < ApplicationController
 
   def update
     if @record.update(record_params)
-      @record.record_items.destroy_all
-      params[:item_ids].each do |item_id|
-        @record.record_items.create(item_id:)
-      end
+      update_record_items
       redirect_to record_path(@record), notice: t('defaults.flash_message.updated', item: Record.model_name.human)
     else
       flash.now[:alert] = t('defaults.flash_message.not_updated', item: Record.model_name.human)
@@ -97,5 +94,30 @@ class RecordsController < ApplicationController
 
   def determine_date
     params[:month] ? Date.strptime(params[:month], '%Y-%m') : Date.current
+  end
+
+  def update_record_items
+    existing_items = @record.record_items.to_a
+    update_existing_items(existing_items)
+    remove_excess_items(existing_items)
+  end
+
+  def update_existing_items(existing_items)
+    params[:item_ids].each_with_index do |item_id, index|
+      if existing_items[index]
+        # 既存のrecord_itemがある場合は更新
+        existing_items[index].update(item_id:)
+      else
+        # 既存のrecord_itemがない場合は作成
+        @record.record_items.create(item_id:)
+      end
+    end
+  end
+
+  # record編集時に不要になったrecord_itemを削除
+  def remove_excess_items(existing_items)
+    return unless existing_items.length > params[:item_ids].length
+
+    existing_items[params[:item_ids].length..].each(&:destroy)
   end
 end

--- a/app/services/user_record_stats_service.rb
+++ b/app/services/user_record_stats_service.rb
@@ -8,7 +8,7 @@ class UserRecordStatsService
   # 日別レコード再生数を集計
   def monthly_creation_count(date)
     from_date, to_date = month_range(date)
-    base_query(from_date, to_date).group_by_day(:created_at).count
+    base_query(from_date, to_date).group_by_day('records.created_at').count
   end
 
   # １ヶ月でよく聞いたアーティストを集計
@@ -55,6 +55,6 @@ class UserRecordStatsService
 
   def base_query(from_date, to_date)
     RecordItem.joins(:record)
-              .where(records: { user_id: @user.id }, record_items: { created_at: from_date..to_date })
+              .where(records: { user_id: @user.id, created_at: from_date..to_date })
   end
 end


### PR DESCRIPTION
# 概要
record_itemsの集計方法を修正

## 内容
レポートをrecord_itemsの作成日時で集計していたため、recordを編集した際にレポートの集計が正しく反映されない問題があった。作成したrecordに紐づくrecord_itemsを後から編集しても、元々のrecordの作成日での集計が維持されるよう以下を修正した。
- UserRecordStatsServiceのbase_queryメソッドで、recordsテーブルのcreated_atを基準とした集計を行うよう変更